### PR TITLE
Fixed loginUser function running on page load when no cookie exists

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -5,13 +5,15 @@ export const LOGIN_USER_START = "LOGIN_USER_START"
 export const LOGIN_USER_SUCCESS = "LOGIN_USER_SUCCESS"
 export const LOGIN_USER_FAIL = "LOGIN_USER_FAIL"
 
+// checks for user_id cookie set on successful login and returns or creates a user based off of it
 export const loginUser = user => async dispatch => {
   dispatch({ type: LOGIN_USER_START })
+  //check for cookie
   const userID = Cookie.get("user_id")
 
   try {
     let result = null
-    //if userID stored in cookie, get user with ID in database
+    //if cookie with userID exists, get user with ID in database
     if (userID) {
       result = await axios.get(`${baseUsersUrl}/${userID}`)
       dispatch({
@@ -22,7 +24,8 @@ export const loginUser = user => async dispatch => {
           },
         },
       })
-    } else {
+      //checks for user object to ensure block only runs for user creation
+    } else if (user) {
       //post request returns user data if user is already in DB or creates user then returns user
       result = await axios.post(`${baseUsersUrl}`, user)
       //sets user_id cookie when user logs in - expires in 7 days


### PR DESCRIPTION
# Description

- loginUser function if/else block changed to only trigger if a user_id cookie exists or a user body is being passed for creation of a new user in DB. This prevents the function from running on page loads when no cookie exists and no user is being created
## Checklist

Remove any items which are not applicable.

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
